### PR TITLE
Wip fix admin not req keystone

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -225,6 +225,7 @@ Keystone Settings
 .. confval:: rgw_keystone_admin_password_path
 .. confval:: rgw_keystone_accepted_roles
 .. confval:: rgw_keystone_token_cache_size
+.. confval:: rgw_keystone_admin_token_required
 .. confval:: rgw_keystone_verify_ssl
 .. confval:: rgw_keystone_service_token_enabled
 .. confval:: rgw_keystone_service_token_accepted_roles

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -799,6 +799,15 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_keystone_admin_token_required
+  type: bool
+  level: advanced
+  desc: Require Keystone admin token for certain operations.
+  fmt_desc: Whether the RGW should require an admin token for admin-level operations when integrating with Keystone. This is relevant when using Keystone for authentication, particularly with the OpenStack Identity API.
+  default: false
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_keystone_service_token_enabled
   type: bool
   level: advanced

--- a/src/rgw/rgw_keystone.cc
+++ b/src/rgw/rgw_keystone.cc
@@ -95,10 +95,6 @@ static inline std::string read_secret(const std::string& file_path)
   return s;
 }
 
-bool keystone_admin_token_required() const {
-  return g_ceph_context->_conf->rgw_keystone_admin_token_required;
-}
-
 std::string CephCtxConfig::get_admin_token() const noexcept
 {
   auto& atv = g_ceph_context->_conf->rgw_keystone_admin_token_path;

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -60,6 +60,10 @@ public:
 
   std::string get_endpoint_url() const noexcept override;
 
+  bool keystone_admin_token_required() const {
+    return g_ceph_context->_conf->rgw_keystone_admin_token_required;
+  }
+
   std::string get_admin_token() const noexcept override;
 
   std::string_view get_admin_user() const noexcept override {

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -232,7 +232,15 @@ add_executable(unittest_rgw_throttle test_rgw_throttle.cc)
 add_ceph_unittest(unittest_rgw_throttle)
 target_link_libraries(unittest_rgw_throttle ${rgw_libs} ${UNITTEST_LIBS})
 
+# unittest_rgw_keystone
+add_executable(unittest_rgw_keystone test_rgw_keystone.cc)
+add_ceph_unittest(unittest_rgw_keystone)
+target_include_directories(unittest_rgw_keystone
+  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
+target_link_libraries(unittest_rgw_keystone ${rgw_libs} ${UNITTEST_LIBS})
+
 add_executable(unittest_rgw_iam_policy test_rgw_iam_policy.cc)
+
 add_ceph_unittest(unittest_rgw_iam_policy)
 target_link_libraries(unittest_rgw_iam_policy
   ${rgw_libs}

--- a/src/test/rgw/test_rgw_keystone.cc
+++ b/src/test/rgw/test_rgw_keystone.cc
@@ -1,5 +1,11 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include "rgw_keystone.h"
+#include "common/dout.h"
+#include "include/common_fwd.h"
+#include "rgw_common.h"
+
+using namespace rgw::keystone;
 
 class MockConfig {
 public:

--- a/src/test/rgw/test_rgw_keystone.cc
+++ b/src/test/rgw/test_rgw_keystone.cc
@@ -1,0 +1,125 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+class MockConfig {
+public:
+    MOCK_METHOD(std::string, get_admin_token, (), (const));
+    MOCK_METHOD(bool, keystone_admin_token_required, (), (const));
+};
+
+class MockTokenCache {
+public:
+    MOCK_METHOD(bool, find_admin, (TokenEnvelope&), ());
+    MOCK_METHOD(void, add_admin, (const TokenEnvelope&), ());
+};
+
+class ServiceTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        dpp = nullptr; // Mock DoutPrefixProvider if needed
+        y = null_yield;
+    }
+
+    MockConfig config;
+    MockTokenCache token_cache;
+    const DoutPrefixProvider* dpp;
+    optional_yield y;
+    std::string token;
+    bool token_cached;
+};
+
+// Test Case 1: Deprecated admin token exists (Pass scenario)
+TEST_F(ServiceTest, GetAdminToken_DeprecatedTokenExists_ReturnsSuccess) {
+    // Arrange
+    std::string expected_token = "deprecated_admin_token_123";
+    EXPECT_CALL(config, get_admin_token())
+        .WillOnce(::testing::Return(expected_token));
+
+    // Act
+    int result = Service::get_admin_token(dpp, token_cache, config, y, token, token_cached);
+
+    // Assert
+    EXPECT_EQ(result, 0);
+    EXPECT_EQ(token, expected_token);
+    EXPECT_FALSE(token_cached); // Not set when using deprecated token
+}
+
+// Test Case 2: No admin token, not required (Pass scenario)
+TEST_F(ServiceTest, GetAdminToken_NotRequired_ReturnsNotFound) {
+    // Arrange
+    EXPECT_CALL(config, get_admin_token())
+        .WillOnce(::testing::Return(""));
+    EXPECT_CALL(config, keystone_admin_token_required())
+        .WillOnce(::testing::Return(false));
+
+    // Act
+    int result = Service::get_admin_token(dpp, token_cache, config, y, token, token_cached);
+
+    // Assert
+    EXPECT_EQ(result, -ENOENT);
+    EXPECT_TRUE(token.empty());
+}
+
+// Test Case 3: Cached token found (Pass scenario)
+TEST_F(ServiceTest, GetAdminToken_CachedTokenFound_ReturnsSuccess) {
+    // Arrange
+    EXPECT_CALL(config, get_admin_token())
+        .WillOnce(::testing::Return(""));
+    EXPECT_CALL(config, keystone_admin_token_required())
+        .WillOnce(::testing::Return(true));
+    
+    TokenEnvelope cached_token;
+    cached_token.token.id = "cached_token_456";
+    
+    EXPECT_CALL(token_cache, find_admin(::testing::_))
+        .WillOnce(::testing::DoAll(
+            ::testing::SetArgReferee<0>(cached_token),
+            ::testing::Return(true)
+        ));
+
+    // Act
+    int result = Service::get_admin_token(dpp, token_cache, config, y, token, token_cached);
+
+    // Assert
+    EXPECT_EQ(result, 0);
+    EXPECT_EQ(token, "cached_token_456");
+    EXPECT_TRUE(token_cached);
+}
+
+// Test Case 4: New token issued successfully (Pass scenario)
+TEST_F(ServiceTest, GetAdminToken_NewTokenIssued_ReturnsSuccess) {
+    // Arrange
+    EXPECT_CALL(config, get_admin_token())
+        .WillOnce(::testing::Return(""));
+    EXPECT_CALL(config, keystone_admin_token_required())
+        .WillOnce(::testing::Return(true));
+    EXPECT_CALL(token_cache, find_admin(::testing::_))
+        .WillOnce(::testing::Return(false));
+    
+    // Mock issue_admin_token_request to return success
+    // This would need to be mocked at the Service class level
+    
+    // Act & Assert would depend on your actual implementation
+    // This test shows the structure needed
+}
+
+// Test Case 5: Token request fails (Fail scenario)
+TEST_F(ServiceTest, GetAdminToken_TokenRequestFails_ReturnsError) {
+    // Arrange
+    EXPECT_CALL(config, get_admin_token())
+        .WillOnce(::testing::Return(""));
+    EXPECT_CALL(config, keystone_admin_token_required())
+        .WillOnce(::testing::Return(true));
+    EXPECT_CALL(token_cache, find_admin(::testing::_))
+        .WillOnce(::testing::Return(false));
+    
+    // Mock issue_admin_token_request to return failure
+    int expected_error = -EACCES;
+    
+    // Act
+    // int result = Service::get_admin_token(dpp, token_cache, config, y, token, token_cached);
+    
+    // Assert
+    // EXPECT_EQ(result, expected_error);
+    // EXPECT_TRUE(token.empty());
+}


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
